### PR TITLE
Handle malformed config entries gracefully

### DIFF
--- a/lib/config_parser.sh
+++ b/lib/config_parser.sh
@@ -3,8 +3,12 @@
 # config_parser.sh - SSH configuration file parser module
 #
 
+PARSE_ERRORS_FILE=""
+
 parse_config_file() {
     local file="$1"
+    local line_num=0
+    local errors_file="${PARSE_ERRORS_FILE:-}"
 
     if [[ ! -r "$file" ]]; then
         echo "ERROR: Cannot read file: $file" >&2
@@ -12,6 +16,9 @@ parse_config_file() {
     fi
 
     while IFS= read -r line || [[ -n "$line" ]]; do
+        ((line_num++))
+        local original_line="$line"
+
         line="${line#"${line%%[![:space:]]*}"}"
         line="${line%"${line##*[![:space:]]}"}"
 
@@ -35,6 +42,10 @@ parse_config_file() {
             value="${BASH_REMATCH[2]}"
             directive=$(normalize_directive "$directive")
             echo "${directive}=${value}"
+        else
+            if [[ -n "$errors_file" ]]; then
+                echo "Line $line_num: Malformed entry: $original_line" >> "$errors_file"
+            fi
         fi
 
     done < "$file"
@@ -203,5 +214,51 @@ get_effective_value() {
         echo "$value"
     else
         echo "$default"
+    fi
+}
+
+parse_config_with_errors() {
+    local file="$1"
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    local output
+    output=$(parse_config_file "$file")
+    PARSE_ERRORS_FILE=""
+
+    echo "$output"
+    echo "ERRORS_FILE:$errors_file"
+}
+
+get_parse_errors() {
+    local errors_file="$1"
+    if [[ -n "$errors_file" && -f "$errors_file" ]]; then
+        cat "$errors_file"
+    fi
+}
+
+has_parse_errors() {
+    local errors_file="$1"
+    if [[ -n "$errors_file" && -f "$errors_file" ]]; then
+        [[ -s "$errors_file" ]]
+    else
+        return 1
+    fi
+}
+
+clear_parse_errors() {
+    local errors_file="$1"
+    if [[ -n "$errors_file" && -f "$errors_file" ]]; then
+        rm -f "$errors_file"
+    fi
+}
+
+count_parse_errors() {
+    local errors_file="$1"
+    if [[ -n "$errors_file" && -f "$errors_file" ]]; then
+        wc -l < "$errors_file"
+    else
+        echo 0
     fi
 }

--- a/ssh-config-auditor.sh
+++ b/ssh-config-auditor.sh
@@ -229,15 +229,28 @@ run_audit() {
 
     log info "Auditing file: $file"
 
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
     local tmpdirectives
     tmpdirectives=$(mktemp)
     parse_config_file "$file" > "$tmpdirectives"
+    PARSE_ERRORS_FILE=""
+
+    if has_parse_errors "$errors_file"; then
+        log warn "Malformed config entries detected in $file:"
+        while IFS= read -r error; do
+            echo "  $error" >&2
+        done < "$errors_file"
+    fi
 
     local -A directives
     while IFS='=' read -r key value; do
         [[ -n "$key" ]] && directives["$key"]="$value"
     done < "$tmpdirectives"
-    rm -f "$tmpdirectives"
+
+    rm -f "$tmpdirectives" "$errors_file"
 
     check_permit_root_login "$file" "${directives[PermitRootLogin]:-}"
     check_password_authentication "$file" "${directives[PasswordAuthentication]:-}"

--- a/tests/test_auditor.sh
+++ b/tests/test_auditor.sh
@@ -239,6 +239,136 @@ test_normalize_directive() {
     fi
 }
 
+test_parse_malformed_entries() {
+    log_test "Parsing config with malformed entries..."
+
+    local config="
+PermitRootLogin no
+123Invalid yes
+PasswordAuthentication yes
+@BadDirective value
+=InvalidStart test
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    local result
+    result=$(parse_config_file "$tmpfile")
+    PARSE_ERRORS_FILE=""
+
+    local error_count
+    error_count=$(count_parse_errors "$errors_file")
+
+    if has_parse_errors "$errors_file" && [[ "$error_count" -eq 3 ]]; then
+        log_pass "Malformed entries detection"
+        rm -f "$errors_file"
+    else
+        log_fail "Malformed entries detection (expected 3 errors, got $error_count)"
+        rm -f "$errors_file"
+    fi
+}
+
+test_parse_error_messages() {
+    log_test "Checking malformed entry error messages..."
+
+    local config="
+PermitRootLogin no
+123Invalid yes
+@BadDirective value
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    local result
+    result=$(parse_config_file "$tmpfile")
+    PARSE_ERRORS_FILE=""
+
+    local errors
+    errors=$(get_parse_errors "$errors_file")
+
+    rm -f "$errors_file"
+
+    if assert_contains "$errors" "Line 3" && \
+       assert_contains "$errors" "Malformed entry" && \
+       assert_contains "$errors" "123Invalid"; then
+        log_pass "Error message format"
+    else
+        log_fail "Error message format"
+    fi
+}
+
+test_clear_parse_errors() {
+    log_test "Testing clear_parse_errors function..."
+
+    local config="
+123Invalid yes
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    parse_config_file "$tmpfile" > /dev/null
+    PARSE_ERRORS_FILE=""
+
+    if has_parse_errors "$errors_file"; then
+        clear_parse_errors "$errors_file"
+        if ! has_parse_errors "$errors_file"; then
+            log_pass "Clear parse errors"
+            rm -f "$errors_file"
+        else
+            log_fail "Clear parse errors (errors still present)"
+            rm -f "$errors_file"
+        fi
+    else
+        log_fail "Clear parse errors (no errors to clear)"
+        rm -f "$errors_file"
+    fi
+}
+
+test_parse_valid_after_malformed() {
+    log_test "Parsing valid entries after malformed ones..."
+
+    local config="
+PermitRootLogin no
+123Invalid yes
+PasswordAuthentication yes
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    local result
+    result=$(parse_config_file "$tmpfile")
+    PARSE_ERRORS_FILE=""
+
+    rm -f "$errors_file"
+
+    if assert_contains "$result" "PermitRootLogin=no" && \
+       assert_contains "$result" "PasswordAuthentication=yes"; then
+        log_pass "Valid entries parsed after malformed"
+    else
+        log_fail "Valid entries parsed after malformed"
+    fi
+}
+
 test_check_permit_root_login_yes() {
     log_test "Checking PermitRootLogin yes (critical)..."
 
@@ -546,6 +676,46 @@ UsePAM yes
     fi
 }
 
+test_full_audit_with_malformed_entries() {
+    log_test "Running audit on config with malformed entries..."
+
+    local config="
+# Config with malformed entries
+PermitRootLogin yes
+123Invalid directive
+@BadDirective value
+PasswordAuthentication yes
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    ISSUES=()
+    declare -A ISSUE_COUNTS=([critical]=0 [high]=0 [medium]=0 [low]=0 [info]=0)
+
+    local parsed
+    parsed=$(parse_config_file "$tmpfile")
+    PARSE_ERRORS_FILE=""
+
+    local has_errors=0
+    if has_parse_errors "$errors_file"; then
+        has_errors=1
+    fi
+    rm -f "$errors_file"
+
+    if assert_contains "$parsed" "PermitRootLogin=yes" && \
+       assert_contains "$parsed" "PasswordAuthentication=yes" && \
+       [[ "$has_errors" -eq 1 ]]; then
+        log_pass "Audit with malformed entries"
+    else
+        log_fail "Audit with malformed entries"
+    fi
+}
+
 run_all_tests() {
     echo ""
     echo "========================================"
@@ -561,6 +731,14 @@ run_all_tests() {
     test_has_directive
     test_parse_list
     test_normalize_directive
+    echo ""
+
+    echo -e "${BLUE}--- Malformed Entry Tests ---${RESET}"
+    test_parse_malformed_entries
+    test_parse_error_messages
+    test_clear_parse_errors
+    test_parse_valid_after_malformed
+    test_full_audit_with_malformed_entries
     echo ""
 
     echo -e "${BLUE}--- Security Checks Tests ---${RESET}"


### PR DESCRIPTION
Added error handling to the config parser to catch and report malformed entries without crashing the audit. The tool now logs warnings for invalid directives while continuing to process valid configuration lines. This prevents a single bad entry from blocking the entire security scan. closes #2