### PR TITLE
Handle malformed config files gracefully

### DIFF
--- a/lib/config_parser.sh
+++ b/lib/config_parser.sh
@@ -262,3 +262,117 @@ count_parse_errors() {
         echo 0
     fi
 }
+
+validate_config_file() {
+    local file="$1"
+    local line_num=0
+    local errors=0
+    local warnings=0
+
+    if [[ ! -f "$file" ]]; then
+        echo "ERROR: Not a regular file: $file" >&2
+        return 1
+    fi
+
+    if [[ ! -r "$file" ]]; then
+        echo "ERROR: Cannot read file: $file" >&2
+        return 1
+    fi
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        ((line_num++))
+        local trimmed_line="$line"
+        trimmed_line="${trimmed_line#"${trimmed_line%%[![:space:]]*}"}"
+
+        [[ -z "$trimmed_line" ]] && continue
+        [[ "$trimmed_line" =~ ^# ]] && continue
+
+        if [[ "$trimmed_line" =~ ^[0-9] ]]; then
+            echo "Line $line_num: Directive cannot start with a digit: $trimmed_line" >&2
+            ((errors++))
+        elif [[ "$trimmed_line" =~ ^[^A-Za-z0-9] ]]; then
+            echo "Line $line_num: Invalid character at start of directive: $trimmed_line" >&2
+            ((errors++))
+        elif [[ ! "$trimmed_line" =~ ^[A-Za-z][A-Za-z0-9]*[[:space:]=] ]]; then
+            echo "Line $line_num: Malformed directive format: $trimmed_line" >&2
+            ((warnings++))
+        fi
+
+    done < "$file"
+
+    if [[ $errors -gt 0 ]]; then
+        return 2
+    elif [[ $warnings -gt 0 ]]; then
+        return 1
+    fi
+
+    return 0
+}
+
+parse_config_strict() {
+    local file="$1"
+    local errors_file="$2"
+    local line_num=0
+    local parsed_count=0
+    local error_count=0
+
+    if [[ ! -r "$file" ]]; then
+        echo "ERROR: Cannot read file: $file" >&2
+        return 1
+    fi
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        ((line_num++))
+        local original_line="$line"
+
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+
+        [[ -z "$line" ]] && continue
+        [[ "$line" =~ ^# ]] && continue
+
+        line="${line%%#*}"
+        line="${line%"${line##*[![:space:]]}"}"
+
+        [[ -z "$line" ]] && continue
+
+        local directive value
+
+        if [[ "$line" =~ ^([A-Za-z][A-Za-z0-9]*)[[:space:]]+(.*) ]]; then
+            directive="${BASH_REMATCH[1]}"
+            value="${BASH_REMATCH[2]}"
+            directive=$(normalize_directive "$directive")
+            echo "${directive}=${value}"
+            ((parsed_count++))
+        elif [[ "$line" =~ ^([A-Za-z][A-Za-z0-9]*)[[:space:]]*=[[:space:]]*(.*) ]]; then
+            directive="${BASH_REMATCH[1]}"
+            value="${BASH_REMATCH[2]}"
+            directive=$(normalize_directive "$directive")
+            echo "${directive}=${value}"
+            ((parsed_count++))
+        else
+            if [[ -n "$errors_file" ]]; then
+                echo "Line $line_num: Malformed entry: $original_line" >> "$errors_file"
+            fi
+            ((error_count++))
+        fi
+
+    done < "$file"
+
+    echo "Parsed: $parsed_count, Errors: $error_count" >&2
+
+    [[ $error_count -eq 0 ]]
+}
+
+get_parse_error_summary() {
+    local errors_file="$1"
+    if [[ ! -n "$errors_file" || ! -f "$errors_file" || ! -s "$errors_file" ]]; then
+        echo "No parse errors found"
+        return 0
+    fi
+
+    local total
+    total=$(wc -l < "$errors_file")
+    echo "Found $total malformed entr(ies):"
+    cat "$errors_file"
+}

--- a/ssh-config-auditor.sh
+++ b/ssh-config-auditor.sh
@@ -232,10 +232,13 @@ run_audit() {
     local errors_file
     errors_file=$(mktemp)
 
-    PARSE_ERRORS_FILE="$errors_file"
     local tmpdirectives
     tmpdirectives=$(mktemp)
-    parse_config_file "$file" > "$tmpdirectives"
+
+    PARSE_ERRORS_FILE="$errors_file"
+    if ! parse_config_strict "$file" > "$tmpdirectives" 2>&1; then
+        log warn "Config file contains malformed entries"
+    fi
     PARSE_ERRORS_FILE=""
 
     if has_parse_errors "$errors_file"; then
@@ -243,14 +246,27 @@ run_audit() {
         while IFS= read -r error; do
             echo "  $error" >&2
         done < "$errors_file"
+        
+        local error_count
+        error_count=$(count_parse_errors "$errors_file")
+        log warn "Total malformed entries: $error_count"
     fi
 
     local -A directives
     while IFS='=' read -r key value; do
-        [[ -n "$key" ]] && directives["$key"]="$value"
+        [[ -z "$key" ]] && continue
+        [[ "$key" =~ ^[0-9]+$ ]] && continue
+        [[ "$key" == "Parsed:"* ]] && continue
+        [[ "$key" == "Errors:"* ]] && continue
+        directives["$key"]="$value"
     done < "$tmpdirectives"
 
     rm -f "$tmpdirectives" "$errors_file"
+
+    if [[ ${#directives[@]} -eq 0 ]]; then
+        log warn "No valid directives found in config file"
+        return 0
+    fi
 
     check_permit_root_login "$file" "${directives[PermitRootLogin]:-}"
     check_password_authentication "$file" "${directives[PasswordAuthentication]:-}"
@@ -311,10 +327,17 @@ main() {
         exit 5
     fi
 
+    local audit_failed=0
     for config_file in "${CONFIG_FILES[@]}"; do
         log info "Processing: $config_file"
-        run_audit "$config_file"
+        if ! run_audit "$config_file"; then
+            audit_failed=1
+        fi
     done
+
+    if [[ $audit_failed -eq 1 && ${#ISSUES[@]} -eq 0 ]]; then
+        exit 5
+    fi
 
     local report
     report=$(generate_report "${ISSUES[@]}")

--- a/tests/test_auditor.sh
+++ b/tests/test_auditor.sh
@@ -369,6 +369,130 @@ PasswordAuthentication yes
     fi
 }
 
+test_validate_config_file_starting_with_digit() {
+    log_test "Validating config with directive starting with digit..."
+
+    local config="
+PermitRootLogin no
+123Invalid yes
+PasswordAuthentication yes
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    parse_config_file "$tmpfile" > /dev/null
+    PARSE_ERRORS_FILE=""
+
+    local errors
+    errors=$(get_parse_errors "$errors_file")
+
+    if assert_contains "$errors" "123Invalid"; then
+        log_pass "Detect directive starting with digit"
+        rm -f "$errors_file"
+    else
+        log_fail "Detect directive starting with digit"
+        rm -f "$errors_file"
+    fi
+}
+
+test_validate_config_file_invalid_start_char() {
+    log_test "Validating config with invalid start character..."
+
+    local config="
+PermitRootLogin no
+@InvalidDirective yes
+PasswordAuthentication yes
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    parse_config_file "$tmpfile" > /dev/null
+    PARSE_ERRORS_FILE=""
+
+    local errors
+    errors=$(get_parse_errors "$errors_file")
+
+    if assert_contains "$errors" "@InvalidDirective"; then
+        log_pass "Detect directive with invalid start character"
+        rm -f "$errors_file"
+    else
+        log_fail "Detect directive with invalid start character"
+        rm -f "$errors_file"
+    fi
+}
+
+test_parse_config_strict() {
+    log_test "Testing strict parsing with error counting..."
+
+    local config="
+PermitRootLogin no
+123Bad value
+PasswordAuthentication yes
+@Invalid test
+Port 22
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    local result
+    result=$(parse_config_strict "$tmpfile" "$errors_file" 2>&1)
+
+    local error_count
+    error_count=$(count_parse_errors "$errors_file")
+
+    if [[ "$error_count" -eq 2 ]]; then
+        log_pass "Strict parsing error count"
+        rm -f "$errors_file"
+    else
+        log_fail "Strict parsing error count (expected 2, got $error_count)"
+        rm -f "$errors_file"
+    fi
+}
+
+test_get_parse_error_summary() {
+    log_test "Testing parse error summary generation..."
+
+    local config="
+123Bad value
+@Invalid test
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    parse_config_file "$tmpfile" > /dev/null
+    PARSE_ERRORS_FILE=""
+
+    local summary
+    summary=$(get_parse_error_summary "$errors_file")
+
+    if assert_contains "$summary" "2" && assert_contains "$summary" "malformed"; then
+        log_pass "Parse error summary"
+        rm -f "$errors_file"
+    else
+        log_fail "Parse error summary"
+        rm -f "$errors_file"
+    fi
+}
+
 test_check_permit_root_login_yes() {
     log_test "Checking PermitRootLogin yes (critical)..."
 
@@ -716,6 +840,78 @@ PasswordAuthentication yes
     fi
 }
 
+test_audit_severely_malformed_config() {
+    log_test "Running audit on severely malformed config..."
+
+    local config="
+123 all numbers
+@special chars!!!
+===more special===
+no_valid_directive_here
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    local parsed
+    parsed=$(parse_config_file "$tmpfile")
+    PARSE_ERRORS_FILE=""
+
+    local error_count
+    error_count=$(count_parse_errors "$errors_file")
+    rm -f "$errors_file"
+
+    if [[ "$error_count" -ge 3 ]]; then
+        log_pass "Severely malformed config detection"
+    else
+        log_fail "Severely malformed config detection (expected >=3 errors, got $error_count)"
+    fi
+}
+
+test_audit_mixed_valid_invalid_config() {
+    log_test "Running audit on mixed valid/invalid config..."
+
+    local config="
+# Mixed config
+PermitRootLogin no
+123Invalid yes
+PasswordAuthentication no
+@BadDir value
+Port 22
+X11Forwarding no
+"
+    local tmpfile
+    tmpfile=$(create_temp_file "$config")
+    TEMP_FILES+=("$tmpfile")
+
+    local errors_file
+    errors_file=$(mktemp)
+
+    PARSE_ERRORS_FILE="$errors_file"
+    local parsed
+    parsed=$(parse_config_file "$tmpfile")
+    PARSE_ERRORS_FILE=""
+
+    local valid_count=0
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && ((valid_count++))
+    done <<< "$parsed"
+
+    local error_count
+    error_count=$(count_parse_errors "$errors_file")
+    rm -f "$errors_file"
+
+    if [[ "$valid_count" -ge 4 && "$error_count" -eq 2 ]]; then
+        log_pass "Mixed valid/invalid config handling"
+    else
+        log_fail "Mixed valid/invalid config handling (valid: $valid_count, errors: $error_count)"
+    fi
+}
+
 run_all_tests() {
     echo ""
     echo "========================================"
@@ -738,7 +934,13 @@ run_all_tests() {
     test_parse_error_messages
     test_clear_parse_errors
     test_parse_valid_after_malformed
+    test_validate_config_file_starting_with_digit
+    test_validate_config_file_invalid_start_char
+    test_parse_config_strict
+    test_get_parse_error_summary
     test_full_audit_with_malformed_entries
+    test_audit_severely_malformed_config
+    test_audit_mixed_valid_invalid_config
     echo ""
 
     echo -e "${BLUE}--- Security Checks Tests ---${RESET}"


### PR DESCRIPTION
Added error handling to detect and report malformed config entries without halting the audit. The parser now logs warnings for invalid directives while continuing to process valid configuration options. Parse error summaries are displayed during execution to help users identify and fix problematic entries. closes #4