### PR TITLE
handle messy config entries gracefully

### DIFF
--- a/lib/config_parser.sh
+++ b/lib/config_parser.sh
@@ -263,57 +263,10 @@ count_parse_errors() {
     fi
 }
 
-validate_config_file() {
-    local file="$1"
-    local line_num=0
-    local errors=0
-    local warnings=0
-
-    if [[ ! -f "$file" ]]; then
-        echo "ERROR: Not a regular file: $file" >&2
-        return 1
-    fi
-
-    if [[ ! -r "$file" ]]; then
-        echo "ERROR: Cannot read file: $file" >&2
-        return 1
-    fi
-
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        ((line_num++))
-        local trimmed_line="$line"
-        trimmed_line="${trimmed_line#"${trimmed_line%%[![:space:]]*}"}"
-
-        [[ -z "$trimmed_line" ]] && continue
-        [[ "$trimmed_line" =~ ^# ]] && continue
-
-        if [[ "$trimmed_line" =~ ^[0-9] ]]; then
-            echo "Line $line_num: Directive cannot start with a digit: $trimmed_line" >&2
-            ((errors++))
-        elif [[ "$trimmed_line" =~ ^[^A-Za-z0-9] ]]; then
-            echo "Line $line_num: Invalid character at start of directive: $trimmed_line" >&2
-            ((errors++))
-        elif [[ ! "$trimmed_line" =~ ^[A-Za-z][A-Za-z0-9]*[[:space:]=] ]]; then
-            echo "Line $line_num: Malformed directive format: $trimmed_line" >&2
-            ((warnings++))
-        fi
-
-    done < "$file"
-
-    if [[ $errors -gt 0 ]]; then
-        return 2
-    elif [[ $warnings -gt 0 ]]; then
-        return 1
-    fi
-
-    return 0
-}
-
 parse_config_strict() {
     local file="$1"
     local errors_file="$2"
     local line_num=0
-    local parsed_count=0
     local error_count=0
 
     if [[ ! -r "$file" ]]; then
@@ -343,13 +296,11 @@ parse_config_strict() {
             value="${BASH_REMATCH[2]}"
             directive=$(normalize_directive "$directive")
             echo "${directive}=${value}"
-            ((parsed_count++))
         elif [[ "$line" =~ ^([A-Za-z][A-Za-z0-9]*)[[:space:]]*=[[:space:]]*(.*) ]]; then
             directive="${BASH_REMATCH[1]}"
             value="${BASH_REMATCH[2]}"
             directive=$(normalize_directive "$directive")
             echo "${directive}=${value}"
-            ((parsed_count++))
         else
             if [[ -n "$errors_file" ]]; then
                 echo "Line $line_num: Malformed entry: $original_line" >> "$errors_file"
@@ -358,8 +309,6 @@ parse_config_strict() {
         fi
 
     done < "$file"
-
-    echo "Parsed: $parsed_count, Errors: $error_count" >&2
 
     [[ $error_count -eq 0 ]]
 }

--- a/ssh-config-auditor.sh
+++ b/ssh-config-auditor.sh
@@ -235,31 +235,29 @@ run_audit() {
     local tmpdirectives
     tmpdirectives=$(mktemp)
 
-    if ! parse_config_strict "$file" "$errors_file" > "$tmpdirectives" 2>&1; then
-        log warn "Config file contains malformed entries"
-    fi
+    # Parse directives to stdout, summary to stderr — keep them separate
+    parse_config_strict "$file" "$errors_file" > "$tmpdirectives"
 
+    # Report any malformed entries found during parsing
     if has_parse_errors "$errors_file"; then
-        log warn "Malformed config entries detected in $file:"
-        while IFS= read -r error; do
-            echo "  $error" >&2
-        done < "$errors_file"
-        
         local error_count
         error_count=$(count_parse_errors "$errors_file")
-        log warn "Total malformed entries: $error_count"
+        log warn "Found $error_count malformed entr(ies) in $file:"
+        while IFS= read -r error_line; do
+            log warn "  $error_line"
+        done < "$errors_file"
     fi
 
+    rm -f "$errors_file"
+
+    # Build directive map from clean parsed output only
     local -A directives
     while IFS='=' read -r key value; do
         [[ -z "$key" ]] && continue
-        [[ "$key" =~ ^[0-9]+$ ]] && continue
-        [[ "$key" == "Parsed:"* ]] && continue
-        [[ "$key" == "Errors:"* ]] && continue
         directives["$key"]="$value"
     done < "$tmpdirectives"
 
-    rm -f "$tmpdirectives" "$errors_file"
+    rm -f "$tmpdirectives"
 
     if [[ ${#directives[@]} -eq 0 ]]; then
         log warn "No valid directives found in config file"


### PR DESCRIPTION
Removed the separate `validate_config_file` pass and the summary echo that was leaking into stdout, which forced fragile filtering logic downstream. Now `parse_config_strict` writes directives to stdout and errors to the errors file only, so the audit loop receives clean key=value pairs without needing to skip count lines or digit keys. The malformed-entry warnings are still surfaced through the normal logging path but no longer contaminate the directive stream. closes #8